### PR TITLE
Splitting out schemata specific to named and linked CRS's.

### DIFF
--- a/src/com/climate/geojson_schema/core.clj
+++ b/src/com/climate/geojson_schema/core.clj
@@ -16,17 +16,19 @@
     [schema.core :refer [Any optional-key required-key eq one pred both either maybe named conditional]]))
 
 (def ^:private named-crs
-  {:type (eq "name")
-   :properties {:name String
-                Any Any}
-   Any Any})
+  (named {:type (eq "name")
+          :properties {:name String
+                       Any Any}
+          Any Any}
+         "invalid named CRS"))
 
 (def ^:private linked-crs
-  {:type (eq "link")
-   :properties {:href String
-                (optional-key :type) String
-                Any Any}
-   Any Any})
+  (named {:type (eq "link")
+          :properties {:href String
+                       (optional-key :type) String
+                       Any Any}
+          Any Any}
+         "invalid linked CRS"))
 
 ;;TBD, there's a requirement that a CRS not be overridden on a sub object per the spec.
 ;; Not sure how to implement that yet.

--- a/src/com/climate/geojson_schema/core.clj
+++ b/src/com/climate/geojson_schema/core.clj
@@ -15,11 +15,24 @@
   (:require
     [schema.core :refer [Any optional-key required-key eq one pred both either maybe]]))
 
+(def ^:private named-crs
+  {:type (eq "name")
+   :properties {:name String
+                Any Any}
+   Any Any})
+
+(def ^:private linked-crs
+  {:type (eq "link")
+   :properties {:href String
+                (optional-key :type) String
+                Any Any}
+   Any Any})
+
 ;;TBD, there's a requirement that a CRS not be overridden on a sub object per the spec.
 ;; Not sure how to implement that yet.
 (def ^:private geojson-crs
-  {:type String
-   :properties (maybe {Any Any})})
+  (either named-crs
+          linked-crs))
 
 (def ^:private position [Number])
 

--- a/src/com/climate/geojson_schema/core.clj
+++ b/src/com/climate/geojson_schema/core.clj
@@ -13,7 +13,7 @@
 ;  limitations under the License.
 (ns com.climate.geojson-schema.core
   (:require
-    [schema.core :refer [Any optional-key required-key eq one pred both either maybe]]))
+    [schema.core :refer [Any optional-key required-key eq one pred both either maybe named conditional]]))
 
 (def ^:private named-crs
   {:type (eq "name")
@@ -31,8 +31,9 @@
 ;;TBD, there's a requirement that a CRS not be overridden on a sub object per the spec.
 ;; Not sure how to implement that yet.
 (def ^:private geojson-crs
-  (either named-crs
-          linked-crs))
+  (named (conditional #(= "name" (:type %)) named-crs
+                      #(= "link" (:type %)) linked-crs)
+         "CRSs should be either named CRSs or linked CRSs."))
 
 (def ^:private position [Number])
 


### PR DESCRIPTION
As far as I can tell these are the only two valid CRS formats.